### PR TITLE
replace deprecated find_executable, add setup.py

### DIFF
--- a/ethtool_exporter.py
+++ b/ethtool_exporter.py
@@ -5,8 +5,8 @@ import os
 import time
 import re
 from argparse import ArgumentParser, Namespace
-from distutils.spawn import find_executable
 from logging import CRITICAL, DEBUG, INFO, Logger, getLogger
+from shutil import which
 from subprocess import PIPE, Popen
 from sys import argv, exit
 from time import sleep
@@ -638,7 +638,7 @@ def _parse_arguments(arguments: List[str]) -> Namespace: # pragma: no cover
 def _get_ethtool_path():
     path = ":".join([os.environ.get("PATH", ""), "/usr/sbin", "/sbin"])
     # Try to find the executable of ethtool.
-    ethtool = find_executable("ethtool", path)
+    ethtool = which("ethtool", path=path)
     if ethtool is None:
         exit("Error: cannot find ethtool.")
     return ethtool # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,46 @@
 #!/usr/bin/env python
 """Setup.py for setuptools and debian packaging."""
 from setuptools import find_packages, setup
-from subprocess import CalledProcessError, check_output
+from subprocess import CalledProcessError, DEVNULL, check_output
 
 
-def version():
+def git_branch():
     try:
-        version = (
-            check_output(["git", "describe", "--exact-match", "--tags"])
+        branch = (
+            check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+            .decode("utf-8")[:8]
+            .strip()
+        )
+    except (CalledProcessError, FileNotFoundError):
+        branch = "unknown"
+    return branch
+
+
+def git_commit():
+    try:
+        sha = check_output(["git", "rev-parse", "HEAD"]).decode("utf-8")[:8].strip()
+    except (CalledProcessError, FileNotFoundError):
+        sha = "unknown"
+    return sha
+
+
+def git_tag():
+    try:
+        tag = (
+            check_output(["git", "describe", "--exact-match", "--tags"], stderr=DEVNULL)
             .decode("utf-8")
             .lstrip("v")
             .strip()
         )
     except (CalledProcessError, FileNotFoundError):
-        version = "unknown"
-    try:
-        sha = check_output(["git", "rev-parse", "HEAD"]).decode("utf-8")[:8]
-    except (CalledProcessError, FileNotFoundError):
-        sha = "unknown"
+        tag = ""
+    return tag
+
+
+def version():
+    tag = git_tag()
+    version = tag if tag else git_branch()
+    sha = git_commit()
     return f"{version}+{sha}"
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""Setup.py for setuptools and debian packaging."""
+from setuptools import find_packages, setup
+from subprocess import CalledProcessError, check_output
+
+
+def version():
+    try:
+        version = (
+            check_output(["git", "describe", "--exact-match", "--tags"])
+            .decode("utf-8")
+            .lstrip("v")
+            .strip()
+        )
+    except (CalledProcessError, FileNotFoundError):
+        version = "unknown"
+    try:
+        sha = check_output(["git", "rev-parse", "HEAD"]).decode("utf-8")[:8]
+    except (CalledProcessError, FileNotFoundError):
+        sha = "unknown"
+    return f"{version}+{sha}"
+
+
+setup(
+    name="ethtool_exporter",
+    version=version(),
+    description="ethtool exporter",
+    scripts=["ethtool_exporter.py"],
+    py_modules=[],
+)


### PR DESCRIPTION
This change replaces deprecated (and to-be removed in Python 3.12) `find_executable` and adds a `setup.py` to ease Debian packaging.